### PR TITLE
WIP:[ImportVerilog] update slang to 3.0 by using exteral package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,7 @@ endif()
 
 option(CIRCT_SLANG_FRONTEND_ENABLED "Enables slang Verilog frontend." ON)
 option(CIRCT_SLANG_BUILD_FROM_SOURCE
-  "Build slang from source instead of finding an installed package" ON)
+  "Build slang from source instead of finding an installed package" OFF)
 
 llvm_canonicalize_cmake_booleans(CIRCT_SLANG_FRONTEND_ENABLED)
 if(CIRCT_SLANG_FRONTEND_ENABLED)
@@ -540,7 +540,8 @@ if(CIRCT_SLANG_FRONTEND_ENABLED)
     install(TARGETS slang_slang unordered_dense EXPORT CIRCTTargets)
     set(CMAKE_CXX_FLAGS ${original_CXX_FLAGS})
   else()
-    find_package(slang 2.0 REQUIRED)
+    find_package(slang 3.0 REQUIRED)
+    find_package(Boost REQUIRED)
   endif()
 endif()
 

--- a/lib/Conversion/ImportVerilog/CMakeLists.txt
+++ b/lib/Conversion/ImportVerilog/CMakeLists.txt
@@ -19,8 +19,26 @@ else ()
   add_compile_options(-Wno-cast-qual)
   # visitor switch statements cover all cases but have default
   add_compile_options(-Wno-covered-switch-default)
+  # several macro flags slang used
+  add_compile_definitions(DEBUG)
+  add_compile_definitions(BOOST_ALL_NO_LIB)
+  add_compile_definitions(SLANG_STATIC_DEFINE)
+  add_compile_definitions(SLANG_USE_BOOST)
+
+  # compiler version check needed in slang 3.0+
+  if(slang_VERSION VERSION_GREATER 3.0)
+    # check Clang version
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
+      message(FATAL_ERROR "Clang version must be >= 16")
+    endif()
+    # check GCC version
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
+      message(FATAL_ERROR "GCC version must be >= 10")
+    endif()
+  endif()
 endif ()
 
+set(CMAKE_CXX_STANDARD 20)
 add_circt_translation_library(CIRCTImportVerilog
   ImportVerilog.cpp
   Structure.cpp


### PR DESCRIPTION
The modifications added the necessary macro definitions for the slang runtime, while importVerilog was missing them.